### PR TITLE
change base image to inwt/rshiny

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pandora-isomemo/base-image:latest
+FROM inwt/r-shiny:4.2.3
 
 ADD . .
 


### PR DESCRIPTION
I changed the base image to the inwt-rshiny image with a newer R Version (4.2.3)

If you need the geo dependencies from the base image in the future, we could change 
it back to the pandora base image.
But I think for now this would be a cleaner and maybe faster approach