### PR TITLE
remove pipe from server because of error 'could not find function "%>%"'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TraceR
 Title: An app to create network-like representations
-Version: 24.07.0.1
+Version: 24.07.0.2
 Authors@R: c(person("Lukas", "Fuchs", email = "lukas.fuchs@inwt-statistics.de", role = c("aut", "cre")))
 Description: An app to create network-like representations.
 License: GPL (>= 3)

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -11,8 +11,9 @@ shinyServer(function(input, output, session) {
 
   # Automatically render the graph after updates
   output$flowchart <- DiagrammeR::renderGrViz({
-    renderFlowchart(graph)  %>%
-      withProgress(message = "Rendering graph...", value = 0.75)
+    withProgress(renderFlowchart(graph),
+                 message = "Rendering graph...",
+                 value = 0.75)
   })
 
   # Download and upload


### PR DESCRIPTION
An error is displayed in the current online version:

![image](https://github.com/user-attachments/assets/268acec7-8ea2-4947-8270-f5ec5993dcab)

This should fix the issue. @f-lukas Could you check and merge this PR?