### PR TITLE
adjust js to fix zooming

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TraceR
 Title: An app to create network-like representations
-Version: 24.10.1
+Version: 24.11.0
 Authors@R: c(person("Lukas", "Fuchs", email = "lukas.fuchs@inwt-statistics.de", role = c("aut", "cre")))
 Description: An app to create network-like representations.
 License: GPL (>= 3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# TraceR 24.11.0
+
+## Bug Fixes
+
+- fix issue with zoom (#17)
+
 # TraceR 24.09.0
 
 ## New Features

--- a/R/01_renderFlowchart.R
+++ b/R/01_renderFlowchart.R
@@ -20,3 +20,54 @@ renderFlowchart <- function(graph) {
     }
   )
 }
+
+#' Initialize panzoom
+#'
+#' @export
+initialize_graph_zooming <- function() {
+  shinyjs::runjs('
+  function initializePanzoom() {
+  var element = document.querySelector("#flowchart svg");
+
+  if (element && element.tagName.toLowerCase() === "svg") {
+    // Check if panzoom is already initialized
+    if (!element.__panzoomInitialized) {
+      panzoom(element, {
+        bounds: true,
+        boundsPadding: 0.1
+      });
+      element.__panzoomInitialized = true; // Mark this SVG as initialized
+    }
+  }
+}
+
+// Function to observe changes in the graph container
+function setupGraphObserver() {
+  var targetNode = document.querySelector("#flowchart");
+  if (!targetNode) {
+    console.error("Flowchart container not found.");
+    return;
+  }
+
+  // Create a mutation observer
+  var observer = new MutationObserver(function (mutationsList) {
+    for (var mutation of mutationsList) {
+      if (mutation.type === "childList") {
+        // Re-run initializePanzoom when new elements are added
+        initializePanzoom();
+      }
+    }
+  });
+
+  // Start observing the container for child changes
+  observer.observe(targetNode, {
+    childList: true,
+    subtree: false // Only observe direct children
+  });
+}
+
+// Initial call to setup observer and panzoom
+setupGraphObserver();
+initializePanzoom();
+')
+}

--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -73,19 +73,5 @@ shinyServer(function(input, output, session) {
   displayNodeId(input, output, outputId = "clickMessage")
 
   # Custom js to add panzoom after the svg was created
-  shinyjs::runjs('
-  function initializePanzoom() {
-    var element = document.querySelector("#flowchart svg");
-    if (element && element.tagName.toLowerCase() === "svg") {
-      panzoom(element, {
-        bounds: true,
-        boundsPadding: 0.1
-      });
-    } else {
-      // Retry after a short delay if the SVG is not available yet
-      setTimeout(initializePanzoom, 100);
-    }
-  }
-  initializePanzoom();  // Initial call to check and start panzoom
-')
+  initialize_graph_zooming()
 })


### PR DESCRIPTION
While the problem is quite simple, I could not solve this with R code and had to adjust the js code instead. After a graph is uploaded, a new dom element is created and as the zooming was only added to the old svg element, it stops working for the new graph. I tried to call the js function again but it is difficult to implement this so that the function is called after the graph has rendered. Therefore I had to adjust the js code instead.

The function checks if new svg elements are created and if this is the case, the panzoom is added to the element. 